### PR TITLE
Get rid of v8, fusl, sandbox

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -19,23 +19,6 @@ group("default") {
     "//services",
     "//shell",
   ]
-
-  if (is_linux) {
-    deps += [
-      "//apps(//build/toolchain/fusl:fusl_${current_cpu})",
-      "//examples(//build/toolchain/fusl:fusl_${current_cpu})",
-      "//fusl",
-      "//services(//build/toolchain/fusl:fusl_${current_cpu})",
-    ]
-  }
-
-  # TODO(cstout): fix sandbox build for fnl/musl
-  if (is_linux && !is_fnl) {
-    deps += [
-      "//sandbox/linux:sandbox",
-      "//sandbox/linux:sandbox_linux_unittests",
-    ]
-  }
 }
 
 # Deprecated name for the default build target.

--- a/src/services/BUILD.gn
+++ b/src/services/BUILD.gn
@@ -51,14 +51,6 @@ group("services") {
       "//services/url_response_disk_cache",
     ]
   }
-
-  # TODO(jamesr): We only support building V8 snapshot data on a linux host
-  # since it needs a 32 bit toolchain and we don't have one configured for mac
-  # hosts.
-  # TODO(cstout): javascript/v8 build support for fnl/musl
-  if (!is_fnl && host_os == "linux") {
-    deps += [ "//services/js" ]
-  }
 }
 
 group("tests") {
@@ -84,13 +76,6 @@ group("tests") {
   if (is_android) {
     deps += [ "//services/contacts:apptests" ]
     deps += [ "//services/notifications:apptests" ]
-  }
-
-  # TODO(jamesr): We only support building V8 snapshot data on a linux host since it
-  # needs a 32 bit toolchain and we don't have one configured for mac hosts.
-  # TODO(cstout): javascript/v8 build support for fnl/musl
-  if (!is_fnl && host_os == "linux") {
-    deps += [ "//services/js:tests" ]
   }
 
   if (is_android || is_linux) {


### PR DESCRIPTION
This removes some dependencies, we might want to re-enable V8 later if we want to use it as a scripting language